### PR TITLE
Update our set to include ippusbxd and liblouisutdml

### DIFF
--- a/package_subscriptions/debcrafters_packages.txt
+++ b/package_subscriptions/debcrafters_packages.txt
@@ -418,6 +418,7 @@ intel-processor-trace
 intltool-debian
 io-stringy
 ipp-usb
+ippusbxd
 iprutils
 iputils
 ipvsadm
@@ -720,6 +721,7 @@ liblockfile
 liblog-any-adapter-screen-perl
 liblog-any-perl
 liblouis
+liblouisutdml
 liblwp-mediatypes-perl
 liblwp-protocol-https-perl
 libmaa


### PR DESCRIPTION
Those are leftovers from the deprecated printing set